### PR TITLE
Update to current vert.x version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
 
         <!-- Dependency Versions -->
         <kafka.version>0.8.2.2</kafka.version>
-        <vertx.version>3.1.0</vertx.version>
+        <vertx.version>3.2.1</vertx.version>
         <guava.version>18.0</guava.version>
         <metrics-core.version>2.2.0</metrics-core.version>
         <metrics-graphite.version>2.2.0</metrics-graphite.version>


### PR DESCRIPTION
There is some strange binary incompatibility between 3.1 and 3.2, so this
update is needed to work with 3.2